### PR TITLE
Link to Verify docs about middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+See the [GOV.UK Verify documentation for working with the German Middleware](https://verify-team-manual.cloudapps.digital/german-middleware/#german-middleware) if you need to know how we run our instance at GDS.
+
+Below is the original readme.
+
 # Governikus eIDAS Middleware
 
 This repository contains the source code of the German eIDAS middleware.


### PR DESCRIPTION
People apparently look for the docs link here, and can't find it. So I've added it to the readme.